### PR TITLE
Make sure _MSC_VER is defined before checking version with MU_EXPAND/MU_NO_EXPAND.

### DIFF
--- a/inc/macro_utils/macro_utils.h
+++ b/inc/macro_utils/macro_utils.h
@@ -345,7 +345,7 @@ __pragma(warning(pop))
 /*according to https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019 this is where VS 2019 starts (1920)*/
 /*this is needed because there is NO /experimental:preprocessor or /Zc:preprocessor for VS 2017, it only exists for C++ compiler... apparently*/
 /*and there's an absolute need to compile with 2017 (read: vcredist 2019 not being available in the environment where the resulting compiled code is run)*/
-#if _MSC_VER < 1920
+#if defined(_MSC_VER) && (_MSC_VER < 1920 )
 /*for anything < VS 2019*/
 #define MU_NOEXPAND(...) __VA_ARGS__
 #define MU_EXPAND(...) __VA_ARGS__

--- a/tests/mu_expand_no_expand_test.c
+++ b/tests/mu_expand_no_expand_test.c
@@ -19,7 +19,7 @@
 /*MU_EXPAND, MU_NOEXPAND to the rescue!*/
 /*static int a[] = { MU_EXPAND(MU_IF(0, MU_NOEXPAND(TRUEB), MU_NOEXPAND(FALSEB))) };*/
 
-#if _MSC_VER >= 1920
+#if defined(_MSC_VER) && (_MSC_VER < 1920 )
 /*MU_EXPAND/MU_NOEXPAND pair*/
 static int a_TRUEBRANCH[] = { MU_EXPAND(MU_IF(1, MU_NOEXPAND(TRUEB), MU_NOEXPAND(FALSEB))) };
 static int a_FALSEBRANCH[] = { MU_EXPAND(MU_IF(0, MU_NOEXPAND(TRUEB), MU_NOEXPAND(FALSEB))) };
@@ -33,7 +33,7 @@ int run_mu_expand_no_expand_tests(void)
     int a2 = (MU_EXPAND(MU_NOEXPAND(1, 3))); /*a2 = (1,3)*/
     POOR_MANS_ASSERT(a2 == 3);
 
-#if _MSC_VER >= 1920
+#if defined(_MSC_VER) && (_MSC_VER < 1920 )
     /*MU_EXPAND/MU_NOEXPAND pair*/
     POOR_MANS_ASSERT(sizeof(a_TRUEBRANCH) / sizeof(a_TRUEBRANCH[0]) == 3);
     POOR_MANS_ASSERT(a_TRUEBRANCH[0] == 1);

--- a/tests/mu_expand_no_expand_test.c
+++ b/tests/mu_expand_no_expand_test.c
@@ -19,7 +19,7 @@
 /*MU_EXPAND, MU_NOEXPAND to the rescue!*/
 /*static int a[] = { MU_EXPAND(MU_IF(0, MU_NOEXPAND(TRUEB), MU_NOEXPAND(FALSEB))) };*/
 
-#if defined(_MSC_VER) && (_MSC_VER < 1920 )
+#if !defined(_MSC_VER) || (_MSC_VER >= 1920 )
 /*MU_EXPAND/MU_NOEXPAND pair*/
 static int a_TRUEBRANCH[] = { MU_EXPAND(MU_IF(1, MU_NOEXPAND(TRUEB), MU_NOEXPAND(FALSEB))) };
 static int a_FALSEBRANCH[] = { MU_EXPAND(MU_IF(0, MU_NOEXPAND(TRUEB), MU_NOEXPAND(FALSEB))) };
@@ -33,7 +33,7 @@ int run_mu_expand_no_expand_tests(void)
     int a2 = (MU_EXPAND(MU_NOEXPAND(1, 3))); /*a2 = (1,3)*/
     POOR_MANS_ASSERT(a2 == 3);
 
-#if defined(_MSC_VER) && (_MSC_VER < 1920 )
+#if !defined(_MSC_VER) || (_MSC_VER >= 1920 )
     /*MU_EXPAND/MU_NOEXPAND pair*/
     POOR_MANS_ASSERT(sizeof(a_TRUEBRANCH) / sizeof(a_TRUEBRANCH[0]) == 3);
     POOR_MANS_ASSERT(a_TRUEBRANCH[0] == 1);


### PR DESCRIPTION
I was having trouble compiling on gcc/linux due to the expand/no_expand macros and their interaction with MU_IF.

Checking `defined(_MSC_VER) && (_MSC_VER < 1920 )` allowed me to get past this problem.

Altered `#if` logic in the test as well so it's tested in linux.