### PR TITLE
[autogenerated] update deps: c-build-tools

### DIFF
--- a/build/devops.yml
+++ b/build/devops.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: bf62823469e9be4c61a99199b7f1c66beeb61b17
+    ref: c8655da60f3b21599ca92b57c81c15860ddfabff
 
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools


### PR DESCRIPTION
## Dependency Updates

### c-build-tools
- `ea8e9f6` Fix C# test file detection for .NET-style naming conventions (#389)
