### PR TITLE
[no begging] [autogenerated] update deps: c-build-tools

### DIFF
--- a/build/devops.yml
+++ b/build/devops.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: azure/c-build-tools
     endpoint: github.com_azure
-    ref: 86f8a8465268eb12a059a24470208db7127c6478
+    ref: 82082c8bdbb8070bd4522786e6627f57adc17083
 
 jobs:
 - template: /pipeline_templates/build_all_flavors.yml@c_build_tools


### PR DESCRIPTION
﻿## Dependency Updates

### c-build-tools
- `82082c8` [MrBot] Build repo_validator_rs with the machine default Rust toolchain (https://github.com/Azure/c-build-tools/pull/425)
- `ad31854` use v19 of build pool (https://github.com/Azure/c-build-tools/pull/428)

