### PR TITLE
cmake: guard optional c-build-tools hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,5 +125,10 @@ if(${run_reals_check})
 endif()
 
 #Insert vld in all executables if so required
-add_vld_if_defined(${CMAKE_CURRENT_SOURCE_DIR})
-add_repo_validation(macro_utils_c)
+if(COMMAND add_vld_if_defined)
+    add_vld_if_defined(${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+if(COMMAND add_repo_validation)
+    add_repo_validation(macro_utils_c)
+endif()


### PR DESCRIPTION
## Summary

- Guard the optional `c-build-tools` CMake hooks before calling them.

## Details

`deps/c-build-tools` is only added when its submodule CMake file exists. The validation hooks it provides are currently called unconditionally at the end of the root `CMakeLists.txt`, so a checkout without initialized submodules can skip loading `c-build-tools` and then fail on undefined CMake commands.

The target and install rules for `macro_utils_c` do not require those hooks, so this keeps the optional validation integration enabled when available while allowing the core project configure path to continue without it.

## Testing

- `git diff --check HEAD~1..HEAD`
- Verified the CMake call path around `deps/c-build-tools` loading and the optional hook calls.

Not run: local CMake configure/build, because this Windows environment does not have `cmake` or a C/C++ compiler installed.